### PR TITLE
Refactor liveview

### DIFF
--- a/cellware/astro/app.py
+++ b/cellware/astro/app.py
@@ -13,7 +13,7 @@ from kivy.uix.screenmanager import Screen
 from kivy.utils import platform
 from kivy.logger import Logger
 from kivy.clock import Clock
-from kivy.metrics import sp
+from kivy.metrics import sp, Metrics
 import pypath
 import astro.uix
 from astro import iconfonts
@@ -84,7 +84,14 @@ class AstroApp(App):
         port = self.config.get(section, 'port')
         return name, host, port
 
+    def log_metrics(self):
+        Logger.info('metrics: Window.size is %sx%s' % Window.size)
+        Logger.info('metrics: dpi = %s' % Metrics.dpi)
+        Logger.info('metrics: density = %s' % Metrics.density)
+        Logger.info('metrics: fontscale = %s' % Metrics.fontscale)
+
     def build(self):
+        self.log_metrics()
         Window.bind(on_keyboard=self.on_keyboard)
         self.exception_handler = MyExceptionHandler()
         self.requests = SmartRequests(self)

--- a/cellware/astro/polarscreen.kv
+++ b/cellware/astro/polarscreen.kv
@@ -73,11 +73,11 @@
         size_hint_x: None
         width: '100dp'
 
-        Spinner:
-            id: camera_model
-            text: 'DSLR'
-            values: 'DSLR', 'Pi Camera'
-            picam: self.text == 'Pi Camera'
+        # Spinner:
+        #     id: camera_model
+        #     text: 'DSLR'
+        #     values: 'DSLR', 'Pi Camera'
+        #     picam: self.text == 'Pi Camera'
 
         ImgFileName:
             id: imgfilename
@@ -98,38 +98,44 @@
             text: "%.2f fps" % root.camera.fps
             color: (1, 0, 0, 1)
 
+        # these are useful only for the picamera: uncomment if/when we need it again
+        # Spinner:
+        #     id: format
+        #     text: 'RAW'
+        #     values: 'RAW', 'MJPG'
+        #     disabled: not root.ids.camera_model.picam
+
+        # Spinner:
+        #     id: resolution
+        #     text: '320x240'
+        #     values: '2592x1944', '1296x972', '640x480', '320x240'
+        #     disabled: not root.ids.camera_model.picam
+
+        # Spinner:
+        #     id: shutter
+        #     text: 'auto'
+        #     values: 'auto', '0.5"', '1"', '1.5"', '2"', '2.5"', '3"', '4"', '5"', '6"'
+        #     disabled: not root.ids.camera_model.picam
+
+        BoxLayout:
+            orientation: 'horizontal'
+            size_hint_y: None
+            height: "50dp"
+
+            IconButton:
+                icon: 'fa-play'
+                font_size: "40dp"
+                on_release: root.start_camera()
+
+            IconButton:
+                icon: 'fa-stop'
+                font_size: "40dp"
+                on_release: root.stop_camera()
+
         Spinner:
             id: focal_length
             text: '45mm'
             values: '45mm', '75mm'
-
-        Spinner:
-            id: format
-            text: 'RAW'
-            values: 'RAW', 'MJPG'
-            disabled: not root.ids.camera_model.picam
-
-        Spinner:
-            id: resolution
-            text: '320x240'
-            values: '2592x1944', '1296x972', '640x480', '320x240'
-            disabled: not root.ids.camera_model.picam
-
-        Spinner:
-            id: shutter
-            text: 'auto'
-            values: 'auto', '0.5"', '1"', '1.5"', '2"', '2.5"', '3"', '4"', '5"', '6"'
-            disabled: not root.ids.camera_model.picam
-
-        IconButton:
-            icon: 'fa-play'
-            font_size: "64sp"
-            on_release: root.start_camera()
-
-        IconButton:
-            icon: 'fa-stop'
-            font_size: "64sp"
-            on_release: root.stop_camera()
 
         BoxLayout:
             id: star_toolbar

--- a/cellware/astro/polarscreen.kv
+++ b/cellware/astro/polarscreen.kv
@@ -1,6 +1,4 @@
 <PolarScreen>:
-    #on_size: root.autoscale()
-
     MyScatterPlaneLayout:
         id: scatter
         do_rotation: False
@@ -25,7 +23,7 @@
             id: stars
             visible: True
             opacity: 1 if self.visible else 0
-            source: "polaris%s.png" % root.ids.focal_length
+            source: "polaris%s.png" % root.ids.focal_length.text
             center: self.width * root.NPx, self.height * root.NPy
             size: root.ids.sky.size
             size_hint: None, None

--- a/cellware/astro/polarscreen.kv
+++ b/cellware/astro/polarscreen.kv
@@ -80,7 +80,6 @@
             text: 'DSLR'
             values: 'DSLR', 'Pi Camera'
             picam: self.text == 'Pi Camera'
-            canon: self.text == 'DSLR'
 
         ImgFileName:
             id: imgfilename
@@ -100,12 +99,6 @@
         Label:
             text: "%.2f fps" % root.camera.fps
             color: (1, 0, 0, 1)
-
-        Spinner:
-            id: fps
-            text: '3'
-            values: '1', '1.5', '2', '3', '5', '10', '15', '25'
-            disabled: not root.ids.camera_model.canon
 
         Spinner:
             id: focal_length
@@ -144,12 +137,6 @@
                 icon: 'fa-stop'
                 font_size: "24sp"
                 on_release: root.stop_camera()
-
-            IconButton:
-                icon: 'fa-circle'
-                font_size: "24sp"
-                color: (1, 0, 0, 1)
-                on_release: root.start_camera(recording=True)
 
         BoxLayout:
             id: star_toolbar

--- a/cellware/astro/polarscreen.kv
+++ b/cellware/astro/polarscreen.kv
@@ -123,20 +123,15 @@
             values: 'auto', '0.5"', '1"', '1.5"', '2"', '2.5"', '3"', '4"', '5"', '6"'
             disabled: not root.ids.camera_model.picam
 
-        BoxLayout:
-            orientation: 'horizontal'
-            size_hint_y: None
-            height: "33dp"
+        IconButton:
+            icon: 'fa-play'
+            font_size: "64sp"
+            on_release: root.start_camera()
 
-            IconButton:
-                icon: 'fa-play'
-                font_size: "24sp"
-                on_release: root.start_camera()
-
-            IconButton:
-                icon: 'fa-stop'
-                font_size: "24sp"
-                on_release: root.stop_camera()
+        IconButton:
+            icon: 'fa-stop'
+            font_size: "64sp"
+            on_release: root.stop_camera()
 
         BoxLayout:
             id: star_toolbar

--- a/cellware/astro/polarscreen.py
+++ b/cellware/astro/polarscreen.py
@@ -65,7 +65,8 @@ class PolarScreen(MyScreen):
 
     def start_camera(self):
         self.ids.imgfilename.disabled = True
-        if self.ids.camera_model.picam:
+        if False and self.ids.camera_model.picam:
+            # picamera code commented out for now
             fmt = self.ids.format.text.lower()
             resolution = self.ids.resolution.text
             shutter = self.ids.shutter.text

--- a/cellware/astro/polarscreen.py
+++ b/cellware/astro/polarscreen.py
@@ -27,7 +27,7 @@ class PolarScreen(MyScreen):
         super(PolarScreen, self).__init__(*args, **kwargs)
         self.ids.imgfilename.load_image = self.load_image
         self.NP = self.app.load_north_pole() # coordinates in the 0-1.0 range
-        self.camera.bind(on_remote_camera_size=self.autoscale)
+        self.camera.bind(on_remote_frame_size=self.autoscale)
 
     def load_image(self):
         imgfile = self.app.image_storage.join(self.ids.imgfilename.last_image)
@@ -46,8 +46,9 @@ class PolarScreen(MyScreen):
         return resp.content
 
     def autoscale(self, *args):
-        scale_x = self.width / float(self.camera.img_width)
-        scale_y = self.height / float(self.camera.img_height)
+        w, h = self.camera.frame_size
+        scale_x = self.width / float(w)
+        scale_y = self.height / float(h)
         self.ids.scatter.scale = min(scale_x, scale_y)
         self.ids.scatter.pos = (0, 0)
 

--- a/cellware/astro/polarscreen.py
+++ b/cellware/astro/polarscreen.py
@@ -62,7 +62,7 @@ class PolarScreen(MyScreen):
         self.ids.imgfilename.disabled = False
         self.camera.stop()
 
-    def start_camera(self, recording=False):
+    def start_camera(self):
         self.ids.imgfilename.disabled = True
         if self.ids.camera_model.picam:
             fmt = self.ids.format.text.lower()
@@ -74,9 +74,8 @@ class PolarScreen(MyScreen):
                 shutter = shutter[:-1]
                 params += '?shutter=%s' % shutter
         else:
-            fps = self.ids.fps.text
-            params = '/camera/liveview/?fps=%s' % fps
-        self.camera.start(params, recording)
+            params = '/camera/liveview/'
+        self.camera.start(params)
 
     def status_click(self):
         box = MessageBox(title='Error',

--- a/cellware/astro/remotecamera.py
+++ b/cellware/astro/remotecamera.py
@@ -142,4 +142,6 @@ class RemoteCamera(EventDispatcher):
                 # you put too many tasks into kivy's @mainthread and things
                 # seems to hang.
                 time.sleep(0.01)
-
+        #
+        # stop the gphoto thread on the remote side
+        requests.get(url + 'stop') # this is a bit of a hack :(

--- a/cellware/astro/remotecamera.py
+++ b/cellware/astro/remotecamera.py
@@ -110,76 +110,106 @@ class RemoteCamera(EventDispatcher):
             self.set_status('Stopped')
             Logger.info('RemoteCamera: stop')
 
-    def _camera_loop(self, url, recording):
-        resp = requests.get(url, stream=True)
-        if resp.status_code == 400:
-            # it's very likely that it's camera not found
-            raise CameraNotFound(resp.text)
-        # treat all the other HTTP errors as exceptions
-        resp.raise_for_status()
-
-        ct = resp.headers['Content-Type']
-        if ct == 'video/x-raw':
-            fmt = 'yuv'
-            width = int(resp.headers['X-Width'])
-            height = int(resp.headers['X-Height'])
-            frame_size = width * height
-            ext = '.%dx%d.yuv' % (width, height)
-        elif ct == 'video/x-motion-jpeg':
-            fmt = 'jpg'
-            width = 0
-            height = 0
-            frame_size = 0
-            ext = '.mjpg'
-        else:
-            raise ValueError('Unsupported Content-Type: %s' % ct)
-
-        if recording:
-            self.set_status('Recording')
-            now = datetime.datetime.now()
-            fname = self.app.storage.join(now.strftime('polaris %Y-%m-%d %H.%M') + ext)
-            Logger.info('RemoteCamera: recording to %s' % fname)
-            outfile = fname.open('wb')
-        else:
-            self.set_status('Playing')
-            outfile = None
-
-        data = ''
+    def _camera_loop(self, url, recording): # XXX kill recording
+        # XXX use requests.session to keep-alive the connection
         self.frame_no = 0
-        tstart = time.time()
+        last_frame_time = time.time()
         while self.running:
-            chunk = resp.raw.read(1024)
-            if outfile:
-                outfile.write(chunk)
-            data += chunk
-            if fmt == 'yuv' and len(data) > frame_size:
-                # got a full frame
-                yuv_data = data[:frame_size]
-                data = data[frame_size:]
-                self.got_frame(tstart)
-                self.set_yuv(yuv_data, width, height)
+            resp = requests.get(url)
+            if resp.status_code == 400:
+                # it's very likely that it's camera not found
+                raise CameraNotFound(resp.text)
+            # treat all the other HTTP errors as exceptions
+            resp.raise_for_status()
+            #
+            ct = resp.headers['Content-Type']
+            # XXX implement support for picam YUV data?
+            assert ct == 'image/jpeg'
+            self.set_jpg(resp.content)
 
-            elif fmt == 'jpg':
-                a = data.find('\xff\xd8') # jpg_start
-                b = data.find('\xff\xd9') # jpg_end
-                if a != -1 and b != -1:
-                    # found a new frame!
-                    jpg_data = data[a:b+2]
-                    data = data[b+2:]
-                    self.got_frame(tstart)
-                    self.set_jpg(jpg_data)
+            t = time.time()
+            elapsed = t - last_frame_time
+            self.fps = 1.0/elapsed
+            last_frame_time = t
+            Logger.info('RemoteCamera: %.2f fps' % self.fps)
+            if elapsed < 0.01:
+                # sleep a bit: for the polaris stream this is not an issue since
+                # it will be at a very low fps. However, if you try to display a
+                # MJPG with an unbounded framerate, if you don't put the sleep
+                # you put too many tasks into kivy's @mainthread and things
+                # seems to hang.
+                time.sleep(0.01)
 
-        if outfile:
-            outfile.close()
+    ## def _camera_loop(self, url, recording):
+    ##     resp = requests.get(url, stream=True)
+    ##     if resp.status_code == 400:
+    ##         # it's very likely that it's camera not found
+    ##         raise CameraNotFound(resp.text)
+    ##     # treat all the other HTTP errors as exceptions
+    ##     resp.raise_for_status()
 
-    def got_frame(self, tstart):
-        self.frame_no += 1
-        t = time.time()
-        self.fps = self.frame_no / (t-tstart)
-        Logger.info('RemoteCamera: %.2f fps' % self.fps)
-        # sleep a bit: for the polaris stream this is not an issue since
-        # it will be at a very low fps. However, if you try to display a
-        # MJPG with an unbounded framerate, if you don't put the sleep
-        # you put too many tasks into kivy's @mainthread and things
-        # seems to hang.
-        time.sleep(0.01)
+    ##     ct = resp.headers['Content-Type']
+    ##     if ct == 'video/x-raw':
+    ##         fmt = 'yuv'
+    ##         width = int(resp.headers['X-Width'])
+    ##         height = int(resp.headers['X-Height'])
+    ##         frame_size = width * height
+    ##         ext = '.%dx%d.yuv' % (width, height)
+    ##     elif ct == 'video/x-motion-jpeg':
+    ##         fmt = 'jpg'
+    ##         width = 0
+    ##         height = 0
+    ##         frame_size = 0
+    ##         ext = '.mjpg'
+    ##     else:
+    ##         raise ValueError('Unsupported Content-Type: %s' % ct)
+
+    ##     if recording:
+    ##         self.set_status('Recording')
+    ##         now = datetime.datetime.now()
+    ##         fname = self.app.storage.join(now.strftime('polaris %Y-%m-%d %H.%M') + ext)
+    ##         Logger.info('RemoteCamera: recording to %s' % fname)
+    ##         outfile = fname.open('wb')
+    ##     else:
+    ##         self.set_status('Playing')
+    ##         outfile = None
+
+    ##     data = ''
+    ##     self.frame_no = 0
+    ##     tstart = time.time()
+    ##     while self.running:
+    ##         chunk = resp.raw.read(1024)
+    ##         if outfile:
+    ##             outfile.write(chunk)
+    ##         data += chunk
+    ##         if fmt == 'yuv' and len(data) > frame_size:
+    ##             # got a full frame
+    ##             yuv_data = data[:frame_size]
+    ##             data = data[frame_size:]
+    ##             self.got_frame(tstart)
+    ##             self.set_yuv(yuv_data, width, height)
+
+    ##         elif fmt == 'jpg':
+    ##             a = data.find('\xff\xd8') # jpg_start
+    ##             b = data.find('\xff\xd9') # jpg_end
+    ##             if a != -1 and b != -1:
+    ##                 # found a new frame!
+    ##                 jpg_data = data[a:b+2]
+    ##                 data = data[b+2:]
+    ##                 self.got_frame(tstart)
+    ##                 self.set_jpg(jpg_data)
+
+    ##     if outfile:
+    ##         outfile.close()
+
+    ## def got_frame(self, tstart):
+    ##     self.frame_no += 1
+    ##     t = time.time()
+    ##     self.fps = self.frame_no / (t-tstart)
+    ##     Logger.info('RemoteCamera: %.2f fps' % self.fps)
+    ##     # sleep a bit: for the polaris stream this is not an issue since
+    ##     # it will be at a very low fps. However, if you try to display a
+    ##     # MJPG with an unbounded framerate, if you don't put the sleep
+    ##     # you put too many tasks into kivy's @mainthread and things
+    ##     # seems to hang.
+    ##     time.sleep(0.01)

--- a/cellware/astro/remotecamera.py
+++ b/cellware/astro/remotecamera.py
@@ -132,6 +132,11 @@ class RemoteCamera(EventDispatcher):
             else:
                 raise ValueError('Unsupported Content-Type: %s' % ct)
 
+            try:
+                self.frame_no = int(resp.headers['X-Frame-Number'])
+            except (KeyError, ValueError):
+                pass
+
             frame_times.append(time.time())
             self.fps = len(frame_times) / (frame_times[-1] - frame_times[0])
             #Logger.info('RemoteCamera: %.2f fps' % self.fps)

--- a/cellware/astro/remotecamera.py
+++ b/cellware/astro/remotecamera.py
@@ -112,11 +112,11 @@ class RemoteCamera(EventDispatcher):
             Logger.info('RemoteCamera: stop')
 
     def _camera_loop(self, url, recording):
-        # XXX use requests.session to keep-alive the connection
+        session = requests.session()
         self.frame_no = 0
         frame_times = collections.deque([time.time()], maxlen=25)
         while self.running:
-            resp = requests.get(url)
+            resp = session.get(url)
             if resp.status_code == 400:
                 # it's very likely that it's camera not found
                 raise CameraNotFound(resp.text)
@@ -144,6 +144,6 @@ class RemoteCamera(EventDispatcher):
                 time.sleep(0.01)
         #
         # stop the gphoto thread on the remote side
-        requests.get(url + 'stop/') # this is a bit of a hack :(
+        session.get(url + 'stop/') # this is a bit of a hack :(
         self.set_status('Stopped')
 

--- a/cellware/astro/remotecamera.py
+++ b/cellware/astro/remotecamera.py
@@ -121,7 +121,7 @@ class RemoteCamera(EventDispatcher):
                 # it's very likely that it's camera not found
                 raise CameraNotFound(resp.text)
             resp.raise_for_status()  # treat all the other HTTP errors as exceptions
-
+            self.set_status('Connected')
             #
             ct = resp.headers['Content-Type']
             if ct == 'image/jpeg':
@@ -144,4 +144,6 @@ class RemoteCamera(EventDispatcher):
                 time.sleep(0.01)
         #
         # stop the gphoto thread on the remote side
-        requests.get(url + 'stop') # this is a bit of a hack :(
+        requests.get(url + 'stop/') # this is a bit of a hack :(
+        self.set_status('Stopped')
+

--- a/cellware/astro/remotecamera.py
+++ b/cellware/astro/remotecamera.py
@@ -37,12 +37,12 @@ class RemoteCamera(EventDispatcher):
     # ==============================
 
     def __init__(self, **kwargs):
-        self.register_event_type('on_remote_camera_size')
+        self.register_event_type('on_remote_frame_size')
         super(RemoteCamera, self).__init__(**kwargs)
-        self.img_width, self.img_height = 480, 320
+        self.frame_size = (0, 0)
         self.running = False
 
-    def on_remote_camera_size(self, *args):
+    def on_remote_frame_size(self, *args):
         pass
 
     def url(self, path):
@@ -78,10 +78,9 @@ class RemoteCamera(EventDispatcher):
         # why.
         stream = io.BytesIO(jpg)
         img = CoreImage(stream, ext="jpg")
-        if (self.img_width != img.width) or (self.img_height != img.height):
-            self.img_width = img.width
-            self.img_height = img.height
-            self.dispatch('on_remote_camera_size')
+        if self.frame_size != img.size:
+            self.frame_size = img.size
+            self.dispatch('on_remote_frame_size')
         self.frame_texture = img.texture
 
     @mainthread
@@ -114,6 +113,7 @@ class RemoteCamera(EventDispatcher):
     def _camera_loop(self, url, recording):
         session = requests.session()
         self.frame_no = 0
+        self.frame_size = (0, 0)
         frame_times = collections.deque([time.time()], maxlen=25)
         while self.running:
             resp = session.get(url)

--- a/cellware/astro/remotecamera.py
+++ b/cellware/astro/remotecamera.py
@@ -134,7 +134,7 @@ class RemoteCamera(EventDispatcher):
 
             frame_times.append(time.time())
             self.fps = len(frame_times) / (frame_times[-1] - frame_times[0])
-            Logger.info('RemoteCamera: %.2f fps, deque size %s' % (self.fps, len(frame_times)))
+            #Logger.info('RemoteCamera: %.2f fps' % self.fps)
             if self.fps > 100:
                 # sleep a bit: for the polaris stream this is not an issue since
                 # it will be at a very low fps. However, if you try to display a

--- a/cellware/main.sh
+++ b/cellware/main.sh
@@ -2,6 +2,11 @@
 
 LG_LEON="--size=854x480 --dpi=220"
 BIG="--size=1708x960 --dpi=220"
+HUAWEI_P9="--size=1920x1080 --dpi=480"
 
-#python main.py $LG_LEON "$@"
-python main.py $BIG "$@"
+#SCREEN=${BIG}
+SCREEN=${HUAWEI_P9}
+export KIVY_METRICS_DENSITY=3 # for HUAWEI_P9
+
+python main.py ${SCREEN} "$@"
+

--- a/piware/fake-gphoto-capture.py
+++ b/piware/fake-gphoto-capture.py
@@ -1,24 +1,20 @@
-import time
 import sys
-from pathlib import Path
+import time
+from gphotocam import iter_mjpg
+
+FPS = 25.0
 
 def main():
     if len(sys.argv) != 2:
-        print('Usage: fake-gphoto-capture.py DIRECTORY')
+        print('Usage: fake-gphoto-capture.py VIDEOFILE')
         sys.exit(1)
-
-    FPS = 35.0
-    delay = 1/FPS
-    d = Path(sys.argv[1])
-    n = len(list(d.glob('frame*.jpg')))
+    filename = sys.argv[1]
     fout = sys.stdout.buffer
-    for i in range(n):
-        fname = d / ('frame%d.jpg' % i)
-        data = fname.read_bytes()
-        fout.write(data)
-        fout.flush()
-        time.sleep(delay)
-
+    with open(filename, 'rb') as f:
+        for frame in iter_mjpg(f):
+            fout.write(frame)
+            fout.flush()
+            time.sleep(1/FPS)
 
 if __name__ == '__main__':
     main()

--- a/piware/gphotocam.py
+++ b/piware/gphotocam.py
@@ -133,6 +133,20 @@ class GPhotoCamera:
         self.gphoto = GPhotoThread(fake_camera_file)
 
     def liveview(self, path):
+        if path == '/camera/liveview/':
+            return self.liveview_frame()
+        elif path == '/camera/liveview/stop/':
+            return self.liveview_stop()
+        else:
+            self.app.start_response('404 Not Found', [])
+            return [('Path not found: %s' % path).encode('utf-8')]
+
+    def liveview_stop(self):
+        self.gphoto.stop()
+        self.app.start_response('200 OK', [])
+        return [b'OK']
+
+    def liveview_frame(self):
         if self.gphoto.state == 'STOPPED':
             print('Starting gphoto thread')
             self.gphoto.start()

--- a/piware/gphotocam.py
+++ b/piware/gphotocam.py
@@ -32,7 +32,7 @@ def iter_mjpg(f, data=b''):
 
 class GPhotoThread:
 
-    TIMEOUT = 2.0 # seconds
+    TIMEOUT = 10.0 # seconds
 
     def __init__(self, fake_camera_file):
         self.fake_camera_file = fake_camera_file

--- a/piware/gphotocam.py
+++ b/piware/gphotocam.py
@@ -32,11 +32,8 @@ def iter_mjpg(f, data=b''):
 
 class GPhotoThread:
 
-    #FAKE_CAPTURE = None
-    #FAKE_CAPTURE = 'gphoto-capture-20s.mjpg'
-    FAKE_CAPTURE = 'sky.mjpg'
-
-    def __init__(self):
+    def __init__(self, fake_camera_file):
+        self.fake_camera_file = fake_camera_file
         self.state = 'STOPPED'
         self.thread = None
         self.last_frame = None
@@ -58,11 +55,8 @@ class GPhotoThread:
     def run(self):
         assert self.state == 'STARTING'
         self.should_stop = False
-        if self.FAKE_CAPTURE:
-            cmd = ['python3',
-                   'fake-gphoto-capture.py',
-                   self.FAKE_CAPTURE
-                   ]
+        if self.fake_camera_file:
+            cmd = ['python3', 'fake-gphoto-capture.py', self.fake_camera_file]
         else:
             cmd = ['gphoto2',
                    #'--port', 'ptpip:192.168.1.180',
@@ -121,11 +115,10 @@ class GPhotoCamera:
     NIKON_CAMERA_FOLDER = '/store_00010001/DCIM/100D5300/'
     CAPTURE_DIR = Path('/tmp/pictures')
 
-    def __init__(self, app, videofile):
+    def __init__(self, app, fake_camera_file):
         self.app = app
-        self.videofile = videofile
         self.CAPTURE_DIR.mkdir(parents=True, exist_ok=True)
-        self.gphoto = GPhotoThread()
+        self.gphoto = GPhotoThread(fake_camera_file)
 
     def liveview(self, path):
         if self.gphoto.state == 'STOPPED':

--- a/piware/polaris.py
+++ b/piware/polaris.py
@@ -9,10 +9,10 @@ from picam import PiCamera
 
 class PolarisApp:
 
-    def __init__(self, videofile=None):
-        if videofile is not None:
-            print('FAKE CAMERA from %s' % videofile)
-        self.gphoto = GPhotoCamera(self, videofile)
+    def __init__(self, fake_camera_file=None):
+        if fake_camera_file is not None:
+            print('FAKE CAMERA from %s' % fake_camera_file)
+        self.gphoto = GPhotoCamera(self, fake_camera_file)
         self.picam = PiCamera(self)
 
     def __call__(self, env, start_response):
@@ -75,7 +75,7 @@ def main(fname):
 
 if __name__ == "__main__":
     if len(sys.argv) == 2:
-        fname = sys.argv[1]
+        fake_camera_file = sys.argv[1]
     else:
-        fname = None
-    main(fname)
+        fake_camera_file = None
+    main(fake_camera_file)


### PR DESCRIPTION
The old liveview read the stream of MJPG frames from gphoto a sent all of them over the network, but it causes problems if the network is not fast enough.

The new solution is:

1. on the raspberry, we start a thread which continuously read the gphoto frames and keeps only the latest
2. on the mobile phone, we ask for the latest frame as often as the network allows

By doing this, I can get ~10fps using the hotspot of my mobile phone.

Moreover, this branch also refactors a bit the UI of the polar screen, and removes a couple of unused features.
